### PR TITLE
Add Dockerfile

### DIFF
--- a/.Dockerignore
+++ b/.Dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: rust
 
+# pin temporarily because rustfmt is not available in nightly
+rust:
+  - nightly-2020-07-11
+
 before_script:
   - rustup component add rustfmt-preview
   - cargo fmt --all -- --check
@@ -7,13 +11,11 @@ before_script:
 matrix:
   include:
     - os: osx
-      rust: nightly
       script:
         - cargo build
         - cargo test --verbose
 
     - os: linux
-      rust: nightly
       script:
         - cargo build
         - cargo test --verbose

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM debian:buster
+
+# common packages
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+  ca-certificates curl file libgmp-dev \
+  build-essential \
+  autoconf automake autotools-dev libtool xutils-dev && \
+  rm -rf /var/lib/apt/lists/*
+
+ENV SSL_VERSION=1.0.2s
+
+RUN curl https://www.openssl.org/source/openssl-$SSL_VERSION.tar.gz -O && \
+  tar -xzf openssl-$SSL_VERSION.tar.gz && \
+  cd openssl-$SSL_VERSION && ./config && make depend && make install && \
+  cd .. && rm -rf openssl-$SSL_VERSION*
+
+ENV OPENSSL_LIB_DIR=/usr/local/ssl/lib \
+  OPENSSL_INCLUDE_DIR=/usr/local/ssl/include \
+  OPENSSL_STATIC=1
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain nightly -y
+ENV PATH=/root/.cargo/bin:$PATH
+RUN rustup default nightly
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY . .
+
+RUN cargo build --release
+
+CMD ["./target/release/tss_cli", "manager"]


### PR DESCRIPTION
- Add Dockerfile
- Pin Rust nightly version to fix CI

---

The latest Rust nightly (`rustc 1.46.0-nightly (9d09331e0 2020-07-12)`) doesn't include rustfmt, causing CI to fail.
This seems to be a reoccurring problem, so proposing we pin the version until rustfmt is being consistently added to nightlies

See more:
rust-lang/rustup#2047
rust-lang/rustup#1566
rust-lang/rustup#1958