### PR TITLE
Pad AES key length

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -50,10 +50,13 @@ pub struct Params {
 }
 
 #[allow(dead_code)]
-pub fn aes_encrypt(key: &[u8], plaintext: &[u8]) -> AEAD {
+pub fn aes_encrypt(key_slice: &[u8], plaintext: &[u8]) -> AEAD {
     let nonce: Vec<u8> = repeat(3).take(12).collect();
     let aad: [u8; 0] = [];
-    let mut gcm = AesGcm::new(KeySize256, key, &nonce[..], &aad);
+    let mut key = [0; 32];
+    key[(32 - key_slice.len())..].copy_from_slice(key_slice);
+
+    let mut gcm = AesGcm::new(KeySize256, &key, &nonce[..], &aad);
     let mut out: Vec<u8> = repeat(0).take(plaintext.len()).collect();
     let mut out_tag: Vec<u8> = repeat(0).take(16).collect();
     gcm.encrypt(&plaintext[..], &mut out[..], &mut out_tag[..]);
@@ -64,11 +67,14 @@ pub fn aes_encrypt(key: &[u8], plaintext: &[u8]) -> AEAD {
 }
 
 #[allow(dead_code)]
-pub fn aes_decrypt(key: &[u8], aead_pack: AEAD) -> Vec<u8> {
+pub fn aes_decrypt(key_slice: &[u8], aead_pack: AEAD) -> Vec<u8> {
     let mut out: Vec<u8> = repeat(0).take(aead_pack.ciphertext.len()).collect();
     let nonce: Vec<u8> = repeat(3).take(12).collect();
     let aad: [u8; 0] = [];
-    let mut gcm = AesGcm::new(KeySize256, key, &nonce[..], &aad);
+    let mut key = [0; 32];
+    key[(32 - key_slice.len())..].copy_from_slice(key_slice);
+
+    let mut gcm = AesGcm::new(KeySize256, &key, &nonce[..], &aad);
     gcm.decrypt(&aead_pack.ciphertext[..], &mut out, &aead_pack.tag[..]);
     out
 }


### PR DESCRIPTION
### Problem
The shared AES key vector built @ https://github.com/cryptochill/tss-ecdsa-cli/blob/ef3b77e4a5e0c2f1fab0a91f5fed5c545aed78b7/src/common/keygen.rs#L127 does not guarantee a length of 32, which can result in the following error:


`
thread 'main' panicked at 'assertion failed: key.len() == 16 || key.len() == 24 || key.len() == 32', /Users/steven/.cargo/registry/src/github.com-1ecc6299db9ec823/rust-crypto-0.2.36/src/aes_gcm.rs:23:9
`

### Fix
Copy key into an 32 length slice to pad missing bytes