### PR TITLE
Remove dependency on rust-crypto to support Apple m1 chips

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 
 # pin temporarily because rustfmt is not available in nightly
 rust:
-  - nightly-2020-07-11
+  - nightly-2021-10-04
 
 before_script:
   - rustup component add rustfmt-preview

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ clap = { version = "2.33", features = ["yaml"] }
 [dependencies.multi-party-ecdsa]
 git = "https://github.com/Hrezaei/multi-party-ecdsa"
 #tag = "v0.3.0"
-branch = "feature/upgrade-crypto"
+branch = "feature/deprecate-rust-crypto"
 
 [patch.crates-io]
 rust-gmp = { version = "0.5.1", features = ["serde_support"], git = "https://github.com/KZen-networks/rust-gmp" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,32 +11,27 @@ name = "tss_cli"
 path = "src/main.rs"
 
 [dependencies]
-rocket = { version = "0.4.2", default-features = false, features = ["tls"] }
-rocket_contrib = { version = "0.4.2" }
+rocket = { version = "0.5.0-rc.1", features = ["json"] }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 hex = "0.4"
 reqwest = { version = "0.10.1", default-features = false, features = ["native-tls", "json", "blocking"] }
 uuid = { version = "0.8", features = ["v4"] }
-rust-crypto = "0.2"
+aes-gcm = "0.9.4"
 libsecp256k1 = "0.3.2"
-paillier = { git = "https://github.com/KZen-networks/rust-paillier", tag = "v0.3.4"}
-zk-paillier = { git = "https://github.com/KZen-networks/zk-paillier", tag = "v0.2.5"}
+curv = { package = "curv-kzen", version = "0.7", default-features = false }
+paillier = { git = "https://github.com/KZen-networks/rust-paillier", tag = "v0.3.10"}
+zk-paillier = { git = "https://github.com/KZen-networks/zk-paillier", tag = "v0.3.12"}
 clap = { version = "2.33", features = ["yaml"] }
 
 [dependencies.multi-party-ecdsa]
-git = "https://github.com/KZen-networks/multi-party-ecdsa"
-tag = "v0.3.0"
-#branch = "master"
-
-[dependencies.curv]
-git = "https://github.com/KZen-networks/curv"
-tag = "v0.2.3"
-features = ["ec_secp256k1"]
+git = "https://github.com/Hrezaei/multi-party-ecdsa"
+#tag = "v0.3.0"
+branch = "feature/upgrade-crypto"
 
 [patch.crates-io]
-rust-gmp = { version = "0.5.0", features = ["serde_support"], git = "https://github.com/KZen-networks/rust-gmp" }
+rust-gmp = { version = "0.5.1", features = ["serde_support"], git = "https://github.com/KZen-networks/rust-gmp" }
 
 [profile.release]
 opt-level = 2

--- a/src/common/hd_keys.rs
+++ b/src/common/hd_keys.rs
@@ -4,7 +4,12 @@ use curv::arithmetic::traits::Converter;
 use curv::cryptographic_primitives::hashing::hmac_sha512;
 use curv::cryptographic_primitives::hashing::traits::KeyedHash;
 use curv::elliptic::curves::traits::*;
-use curv::{BigInt, FE, GE};
+use curv::{
+    BigInt,
+    elliptic::curves::secp256_k1::{FE, GE},
+    arithmetic::{BasicOps, One}
+};
+
 
 pub fn get_hd_key(y_sum: &GE, path_vector: Vec<BigInt>) -> (GE, FE) {
     // generate a random but shared chain code, this will do
@@ -40,7 +45,7 @@ pub fn hd_key(
     let f_l_fe: FE = ECScalar::from(&f_l);
     let f_r_fe: FE = ECScalar::from(&f_r);
 
-    let bn_to_slice = BigInt::to_vec(chain_code_bi);
+    let bn_to_slice = BigInt::to_bytes(chain_code_bi);
     let chain_code = GE::from_bytes(&bn_to_slice[1..33]).unwrap() * &f_r_fe;
     let g: GE = ECPoint::generator();
     let pub_key = *pubkey + g * &f_l_fe;

--- a/src/common/manager.rs
+++ b/src/common/manager.rs
@@ -2,12 +2,14 @@ use std::collections::HashMap;
 use std::sync::RwLock;
 
 use rocket::{post, routes, State};
-use rocket_contrib::json::Json;
+use rocket::serde::json::Json;
+
 use uuid::Uuid;
 
 use crate::common::{Entry, Index, Key, Params, PartySignup};
 
-pub fn run_manager() {
+#[rocket::main]
+pub async fn run_manager() -> Result<(), rocket::Error> {
     //     let mut my_config = Config::development();
     //     my_config.set_port(18001);
     let db: HashMap<Key, String> = HashMap::new();
@@ -42,15 +44,16 @@ pub fn run_manager() {
         hm.insert(sign_key, serde_json::to_string(&party_signup_sign).unwrap());
     }
     /////////////////////////////////////////////////////////////////
-    rocket::ignite()
+    rocket::build()
         .mount("/", routes![get, set, signup_keygen, signup_sign])
         .manage(db_mtx)
-        .launch();
+        .launch()
+        .await
 }
 
 #[post("/get", format = "json", data = "<request>")]
 fn get(
-    db_mtx: State<RwLock<HashMap<Key, String>>>,
+    db_mtx: &State<RwLock<HashMap<Key, String>>>,
     request: Json<Index>,
 ) -> Json<Result<Entry, ()>> {
     let index: Index = request.0;
@@ -68,7 +71,7 @@ fn get(
 }
 
 #[post("/set", format = "json", data = "<request>")]
-fn set(db_mtx: State<RwLock<HashMap<Key, String>>>, request: Json<Entry>) -> Json<Result<(), ()>> {
+fn set(db_mtx: &State<RwLock<HashMap<Key, String>>>, request: Json<Entry>) -> Json<Result<(), ()>> {
     let entry: Entry = request.0;
     let mut hm = db_mtx.write().unwrap();
     hm.insert(entry.key.clone(), entry.value.clone());
@@ -77,7 +80,7 @@ fn set(db_mtx: State<RwLock<HashMap<Key, String>>>, request: Json<Entry>) -> Jso
 
 #[post("/signupkeygen", format = "json", data = "<request>")]
 fn signup_keygen(
-    db_mtx: State<RwLock<HashMap<Key, String>>>,
+    db_mtx: &State<RwLock<HashMap<Key, String>>>,
     request: Json<Params>,
 ) -> Json<Result<PartySignup, ()>> {
     let parties = request.parties.parse::<u16>().unwrap();
@@ -118,7 +121,7 @@ fn signup_keygen(
 
 #[post("/signupsign", format = "json", data = "<request>")]
 fn signup_sign(
-    db_mtx: State<RwLock<HashMap<Key, String>>>,
+    db_mtx: &State<RwLock<HashMap<Key, String>>>,
     request: Json<Params>,
 ) -> Json<Result<PartySignup, ()>> {
     let threshold = request.threshold.parse::<u16>().unwrap();

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -5,15 +5,14 @@ pub mod signer;
 
 use std::{iter::repeat, thread, time, time::Duration};
 
-use crypto::{
-    aead::{AeadDecryptor, AeadEncryptor},
-    aes::KeySize::KeySize256,
-    aes_gcm::AesGcm,
-};
+use aes_gcm::{Aes256Gcm, Nonce};
+use aes_gcm::aead::{NewAead, Aead, Payload};
+
 use curv::{
     arithmetic::traits::Converter,
+    elliptic::curves::secp256_k1::{FE, GE},
     elliptic::curves::traits::{ECPoint, ECScalar},
-    BigInt, FE, GE,
+    BigInt,
 };
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
@@ -50,33 +49,53 @@ pub struct Params {
 }
 
 #[allow(dead_code)]
-pub fn aes_encrypt(key_slice: &[u8], plaintext: &[u8]) -> AEAD {
-    let nonce: Vec<u8> = repeat(3).take(12).collect();
-    let aad: [u8; 0] = [];
-    let mut key = [0; 32];
-    key[(32 - key_slice.len())..].copy_from_slice(key_slice);
+pub fn aes_encrypt(key: &[u8], plaintext: &[u8]) -> AEAD {
 
-    let mut gcm = AesGcm::new(KeySize256, &key, &nonce[..], &aad);
-    let mut out: Vec<u8> = repeat(0).take(plaintext.len()).collect();
-    let mut out_tag: Vec<u8> = repeat(0).take(16).collect();
-    gcm.encrypt(&plaintext[..], &mut out[..], &mut out_tag[..]);
+    let mut full_length_key:[u8; 32] = [0; 32];
+    full_length_key[(32 - key.len())..].copy_from_slice(key);//Pad key with zeros
+
+    let aes_key = aes_gcm::Key::from_slice(full_length_key.as_slice());
+    let cipher = Aes256Gcm::new(aes_key);
+
+    let nonce_vector: Vec<u8> = repeat(3).take(12).collect();
+    let nonce = Nonce::from_slice(nonce_vector.as_slice());
+
+    let out_tag: Vec<u8> = repeat(0).take(16).collect();
+
+    let text_payload = Payload {
+        msg: plaintext,
+        aad: &out_tag.as_slice()
+    };
+
+    let ciphertext = cipher.encrypt(nonce, text_payload)
+        .expect("encryption failure!"); // NOTE: handle this error to avoid panics!
+
     AEAD {
-        ciphertext: out.to_vec(),
+        ciphertext: ciphertext,
         tag: out_tag.to_vec(),
     }
 }
 
 #[allow(dead_code)]
-pub fn aes_decrypt(key_slice: &[u8], aead_pack: AEAD) -> Vec<u8> {
-    let mut out: Vec<u8> = repeat(0).take(aead_pack.ciphertext.len()).collect();
-    let nonce: Vec<u8> = repeat(3).take(12).collect();
-    let aad: [u8; 0] = [];
-    let mut key = [0; 32];
-    key[(32 - key_slice.len())..].copy_from_slice(key_slice);
+pub fn aes_decrypt(key: &[u8], aead_pack: AEAD) -> Vec<u8> {
 
-    let mut gcm = AesGcm::new(KeySize256, &key, &nonce[..], &aad);
-    gcm.decrypt(&aead_pack.ciphertext[..], &mut out, &aead_pack.tag[..]);
-    out
+    let mut full_length_key:[u8; 32] = [0; 32];
+    full_length_key[(32 - key.len())..].copy_from_slice(key);//Pad key with zeros
+
+    let aes_key = aes_gcm::Key::from_slice(full_length_key.as_slice());
+
+    let nonce_vector: Vec<u8> = repeat(3).take(12).collect();
+    let nonce = Nonce::from_slice(nonce_vector.as_slice());
+
+    let gcm = Aes256Gcm::new(aes_key);
+
+    let text_payload = Payload {
+        msg: aead_pack.ciphertext.as_slice(),
+        aad: aead_pack.tag.as_slice()
+    };
+
+    let out = gcm.decrypt(nonce, text_payload);
+    out.unwrap_or_default()
 }
 
 pub fn postb<T>(addr: &String, client: &Client, path: &str, body: T) -> Option<String>
@@ -208,7 +227,7 @@ pub fn poll_for_p2p(
 pub fn check_sig(r: &FE, s: &FE, msg: &BigInt, pk: &GE) {
     use secp256k1::{verify, Message, PublicKey, PublicKeyFormat, Signature};
 
-    let raw_msg = BigInt::to_vec(&msg);
+    let raw_msg = BigInt::to_bytes(&msg);
     let mut msg: Vec<u8> = Vec::new(); // padding
     msg.extend(vec![0u8; 32 - raw_msg.len()]);
     msg.extend(raw_msg.iter());

--- a/src/common/signer.rs
+++ b/src/common/signer.rs
@@ -142,7 +142,7 @@ pub fn sign(
 
     //////////////////////////////////////////////////////////////////////////////
     let (com, decommit) = sign_keys.phase1_broadcast();
-    let m_a_k = MessageA::a(&sign_keys.k_i, &party_keys.ek, &[]);
+    let (m_a_k, _) = MessageA::a(&sign_keys.k_i, &party_keys.ek, &[]);
     assert!(broadcast(
         &addr,
         &client,
@@ -400,7 +400,12 @@ pub fn sign(
         &client,
         party_num_int.clone(),
         "round6",
-        serde_json::to_string(&(phase_5a_decom.clone(), helgamal_proof.clone())).unwrap(),
+        serde_json::to_string(&(
+            phase_5a_decom.clone(),
+            helgamal_proof.clone(),
+            dlog_proof_rho.clone()
+        ))
+        .unwrap(),
         uuid.clone(),
     )
     .is_ok());

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,7 +176,7 @@ fn main() {
         ("keygen", Some(sub_matches)) => {
             let addr = sub_matches
                 .value_of("manager_addr")
-                .unwrap_or("http://127.0.0.1:8000")
+                .unwrap_or("http://127.0.0.1:8001")
                 .to_string();
             let keysfile_path = sub_matches.value_of("keysfile").unwrap_or("").to_string();
 


### PR DESCRIPTION
Based on the [PR #149](https://github.com/ZenGo-X/multi-party-ecdsa/pull/149) on multi-party-ecdsa, here are the changes to make this cli compatible with the new Apple M1 silicon chips. 

Needless to say, this version is now [dependent](https://github.com/Hrezaei/tss-ecdsa-cli/blob/5301eb80e569b77edda7de813a36bb2eb481ad5e/Cargo.toml#L29) on [my fork](https://github.com/Hrezaei/multi-party-ecdsa) of multi-party-ecdsa and need to be updated once the above PR got accepted.