### PR TITLE
Fix the error when signatures from different set of shares or different messages are sent in parallel

### DIFF
--- a/src/common/keygen.rs
+++ b/src/common/keygen.rs
@@ -15,10 +15,7 @@ use multi_party_ecdsa::protocols::multi_party_ecdsa::gg_2018::party_i::{
 use paillier::EncryptionKey;
 use reqwest::blocking::Client;
 
-use crate::common::{
-    aes_decrypt, aes_encrypt, broadcast, poll_for_broadcasts, poll_for_p2p, postb, sendp2p, Params,
-    PartySignup, AEAD,
-};
+use crate::common::{aes_decrypt, aes_encrypt, broadcast, poll_for_broadcasts, poll_for_p2p, postb, sendp2p, PartySignup, AEAD, KeygenParams};
 
 pub fn run_keygen(addr: &String, keysfile_path: &String, params: &Vec<&str>) {
     let THRESHOLD: u16 = params[0].parse::<u16>().unwrap();
@@ -34,7 +31,7 @@ pub fn run_keygen(addr: &String, keysfile_path: &String, params: &Vec<&str>) {
     };
 
     //signup:
-    let tn_params = Params {
+    let tn_params = KeygenParams {
         threshold: THRESHOLD.to_string(),
         parties: PARTIES.to_string(),
     };
@@ -262,7 +259,7 @@ pub fn run_keygen(addr: &String, keysfile_path: &String, params: &Vec<&str>) {
     fs::write(&keysfile_path, keygen_json).expect("Unable to save !");
 }
 
-pub fn keygen_signup(addr: &String, client: &Client, params: &Params) -> Result<PartySignup, ()> {
+pub fn keygen_signup(addr: &String, client: &Client, params: &KeygenParams) -> Result<PartySignup, ()> {
     let res_body = postb(&addr, &client, "signupkeygen", params).unwrap();
     serde_json::from_str(&res_body).unwrap()
 }

--- a/src/common/manager.rs
+++ b/src/common/manager.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::RwLock;
 
-use rocket::{post, routes, State};
+use rocket::{post, routes, Ignite, Rocket, State};
 use rocket::serde::json::Json;
 
 use uuid::Uuid;
@@ -9,7 +9,7 @@ use uuid::Uuid;
 use crate::common::{Entry, Index, Key, Params, PartySignup};
 
 #[rocket::main]
-pub async fn run_manager() -> Result<(), rocket::Error> {
+pub async fn run_manager() -> Result<Rocket<Ignite>, rocket::Error> {
     //     let mut my_config = Config::development();
     //     my_config.set_port(18001);
     let db: HashMap<Key, String> = HashMap::new();

--- a/src/common/manager.rs
+++ b/src/common/manager.rs
@@ -6,7 +6,7 @@ use rocket::serde::json::Json;
 
 use uuid::Uuid;
 
-use crate::common::{Entry, Index, Key, Params, PartySignup};
+use crate::common::{Entry, Index, Key, KeygenParams, SignParams, PartySignup};
 
 #[rocket::main]
 pub async fn run_manager() -> Result<Rocket<Ignite>, rocket::Error> {
@@ -81,7 +81,7 @@ fn set(db_mtx: &State<RwLock<HashMap<Key, String>>>, request: Json<Entry>) -> Js
 #[post("/signupkeygen", format = "json", data = "<request>")]
 fn signup_keygen(
     db_mtx: &State<RwLock<HashMap<Key, String>>>,
-    request: Json<Params>,
+    request: Json<KeygenParams>,
 ) -> Json<Result<PartySignup, ()>> {
     let parties = request.parties.parse::<u16>().unwrap();
     let key = "signup-keygen".to_string();
@@ -122,16 +122,29 @@ fn signup_keygen(
 #[post("/signupsign", format = "json", data = "<request>")]
 fn signup_sign(
     db_mtx: &State<RwLock<HashMap<Key, String>>>,
-    request: Json<Params>,
+    request: Json<SignParams>,
 ) -> Json<Result<PartySignup, ()>> {
     let threshold = request.threshold.parse::<u16>().unwrap();
-    let key = "signup-sign".to_string();
+    let x = &request.x;
+    let y = &request.y;
+    let message = &request.message;
+
+    // Modify the key to include x and y values
+    let key = format!("signup-sign-{}-{}-{}", x, y, message);
 
     let mut hm = db_mtx.write().unwrap();
 
     let party_signup = {
-        let value = hm.get(&key).unwrap();
-        let client_signup: PartySignup = serde_json::from_str(&value).unwrap();
+        let value = hm.entry(key.clone()).or_insert_with(|| {
+            let initial_signup = PartySignup {
+                number: 0,
+                uuid: Uuid::new_v4().to_string(),
+            };
+            serde_json::to_string(&initial_signup).unwrap()
+        });
+
+        let client_signup: PartySignup = serde_json::from_str(value).unwrap();
+
         if client_signup.number < threshold + 1 {
             PartySignup {
                 number: client_signup.number + 1,
@@ -144,6 +157,7 @@ fn signup_sign(
             }
         }
     };
+
     if party_signup.number == threshold + 1 {
         hm.insert(
             key,
@@ -151,7 +165,7 @@ fn signup_sign(
                 number: 0,
                 uuid: Uuid::new_v4().to_string(),
             })
-            .unwrap(),
+                .unwrap(),
         );
     } else {
         hm.insert(key, serde_json::to_string(&party_signup).unwrap());

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -43,9 +43,18 @@ pub struct Entry {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct Params {
+pub struct SignParams {
     pub parties: String,
     pub threshold: String,
+    pub x: String,
+    pub y: String,
+    pub message: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct KeygenParams {
+    pub parties: String,
+    pub threshold: String
 }
 
 #[allow(dead_code)]

--- a/src/common/signer.rs
+++ b/src/common/signer.rs
@@ -23,7 +23,7 @@ use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use crate::common::{broadcast, poll_for_broadcasts, poll_for_p2p, sendp2p, Params, PartySignup};
+use crate::common::{broadcast, poll_for_broadcasts, poll_for_p2p, sendp2p, SignParams, PartySignup};
 
 #[derive(Hash, PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
 pub struct TupleKey {
@@ -41,7 +41,7 @@ pub fn sign(
     vss_scheme_vec: &mut Vec<VerifiableSS<GE>>,
     paillier_key_vector: Vec<EncryptionKey>,
     y_sum: &GE,
-    params: &Params,
+    params: &SignParams,
     message: &[u8],
     f_l_new: &FE,
     sign_at_path: bool,
@@ -623,7 +623,7 @@ where
     Some(res.unwrap().text().unwrap())
 }
 
-pub fn signup(addr: &String, client: &Client, params: &Params) -> Result<PartySignup, ()> {
+pub fn signup(addr: &String, client: &Client, params: &SignParams) -> Result<PartySignup, ()> {
     let res_body = postb(&addr, &client, "signupsign", params).unwrap();
     let answer: Result<PartySignup, ()> = serde_json::from_str(&res_body).unwrap();
     return answer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use multi_party_ecdsa::protocols::multi_party_ecdsa::gg_2018::party_i::*;
 use paillier::*;
 use serde_json::json;
 
-use common::{hd_keys, keygen, manager, signer, Params};
+use common::{hd_keys, keygen, manager, signer, SignParams};
 
 mod common;
 mod test;
@@ -128,7 +128,7 @@ fn main() {
                 println!("{}", ret_dict.to_string());
             } else if let Some(sub_matches) = matches.subcommand_matches("sign") {
                 // Parse message to sign
-                let message_str = sub_matches.value_of("message").unwrap_or("");
+                let message_str = sub_matches.value_of("message").unwrap_or("").to_string();
                 let message = match hex::decode(message_str.clone()) {
                     Ok(x) => x,
                     Err(_e) => message_str.as_bytes().to_vec(),
@@ -146,9 +146,12 @@ fn main() {
                     .split("/")
                     .collect();
                 //            println!("sign me {:?} / {:?} / {:?}", manager_addr, message, params);
-                let params = Params {
+                let params = SignParams {
                     threshold: params[0].to_string(),
                     parties: params[1].to_string(),
+                    x: y_sum.x_coor().unwrap().to_str_radix(10),
+                    y: y_sum.x_coor().unwrap().to_str_radix(10),
+                    message: message_str,
                 };
                 signer::sign(
                     manager_addr,


### PR DESCRIPTION
Now we can request different signatures from different set of shares in parallel without errors, it will just wait until the threshold for them is reached before proceeding instead of failing